### PR TITLE
bump semistandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "nodemon": "^1.11.0",
     "nyc": "^9.0.1",
     "request": "^2.73.0",
-    "semistandard": "^8.0.0",
+    "semistandard": "^9.2.1",
     "supertest": "^2.0.1"
   },
   "semistandard": {


### PR DESCRIPTION
This new version has a lighter set of dependencies, which should improve `npm install` speed.